### PR TITLE
Fixed parsing for trees that have version 0.0.3

### DIFF
--- a/craftai/client.py
+++ b/craftai/client.py
@@ -11,7 +11,7 @@ from craftai.operators import _OPERATORS
 
 
 class CraftAIClient(object):
-    """docstring for CraftAIClient"""
+    """Client class for craft ai's API"""
 
     def __init__(self, cfg):
         self._base_url = ""
@@ -372,8 +372,7 @@ class CraftAIClient(object):
                 )
             bare_tree = tree_object[1]
             model = {}
-        elif (semver.Version(tree_version) == semver.Version("0.0.2") or
-              semver.Version(tree_version) == semver.Version("0.0.3")):
+        elif semver.Version(tree_version) == semver.Version("0.0.2"):
             if (len(tree_object) < 2 or
                     not tree_object[1].get("model")):
                 raise CraftAIDecisionError(
@@ -385,6 +384,18 @@ class CraftAIClient(object):
                 )
             bare_tree = tree_object[2]
             model = tree_object[1]["model"]
+        elif semver.Version(tree_version) == semver.Version("0.0.3"):
+            if (len(tree_object) < 2 or
+                    not tree_object[1]):
+                raise CraftAIDecisionError(
+                    """Invalid decision tree format, no model found"""
+                )
+            if len(tree_object) < 3:
+                raise CraftAIDecisionError(
+                    """Invalid decision tree format, no tree found."""
+                )
+            bare_tree = tree_object[2]
+            model = tree_object[1]
         else:
             raise CraftAIDecisionError(
                 """Invalid decision tree format, {} is not a supported"""

--- a/tests/data/interpreter/expectations/blind3.json
+++ b/tests/data/interpreter/expectations/blind3.json
@@ -1,0 +1,28 @@
+[
+  {
+    "title": "allows 0 as value",
+    "context": {
+      "timeOfDay": 0,
+      "dayOfWeek": 0,
+      "solarTime" : -1
+    },
+    "output": {
+      "confidence": 0.9973323941230774,
+      "context": {
+        "dayOfWeek": 0,
+        "solarTime": -1,
+        "timeOfDay": 0
+      },
+      "decision": {
+        "state": "Down"
+      },
+      "predicates": [
+        {
+          "op": "continuous.lessthan",
+          "property": "timeOfDay",
+          "value": "6"
+       }
+      ]
+    }
+  }
+  ]

--- a/tests/data/interpreter/trees/blind3.json
+++ b/tests/data/interpreter/trees/blind3.json
@@ -1,0 +1,99 @@
+[
+  {
+    "version": "0.0.3"
+  },
+  {
+    "context": {
+      "timeOfDay": {
+        "type": "continuous"
+      },
+      "dayOfWeek": {
+        "type": "continuous"
+      },
+      "solarTime": {
+        "type": "continuous"
+      },
+      "state": {
+        "type": "enum"
+      }
+    },
+    "output": [
+      "state"
+    ],
+    "time_quantum": 6000,
+    "deactivate_sampling": true
+  },
+  {
+    "children": [
+      {
+        "confidence": 0.9973323941230774,
+        "predicate": {
+          "op": "continuous.lessthan",
+          "value": "6"
+        },
+        "value": "Down"
+      },
+      {
+        "children": [
+          {
+            "children": [
+              {
+                "confidence": 0.9982397556304932,
+                "predicate": {
+                  "op": "continuous.lessthan",
+                  "value": "5"
+                },
+                "value": "Up"
+              },
+              {
+                "children": [
+                  {
+                    "confidence": 0.9869475960731506,
+                    "predicate": {
+                      "op": "continuous.lessthan",
+                      "value": "10"
+                    },
+                    "value": "Down"
+                  },
+                  {
+                    "confidence": 0.9937745332717896,
+                    "predicate": {
+                      "op": "continuous.greaterthanorequal",
+                      "value": "10"
+                    },
+                    "value": "Up"
+                  }
+                ],
+                "predicate": {
+                  "op": "continuous.greaterthanorequal",
+                  "value": "5"
+                },
+                "predicate_property": "timeOfDay"
+              }
+            ],
+            "predicate": {
+              "op": "continuous.lessthan",
+              "value": "19"
+            },
+            "predicate_property": "dayOfWeek"
+          },
+          {
+            "confidence": 0.9966108202934265,
+            "predicate": {
+              "op": "continuous.greaterthanorequal",
+              "value": "19"
+            },
+            "value": "Down"
+          }
+        ],
+        "predicate": {
+          "op": "continuous.greaterthanorequal",
+          "value": "6"
+        },
+        "predicate_property": "timeOfDay"
+      }
+    ],
+    "output_property": "state",
+    "predicate_property": "timeOfDay"
+  }
+]


### PR DESCRIPTION
* These trees don't have a model key but only a the context itself. The new version takes this into account.