### PR TITLE
Fix timezone

### DIFF
--- a/craftai/time.py
+++ b/craftai/time.py
@@ -67,7 +67,7 @@ class Time(object):
         self.time_of_day = time.hour + time.minute / 60 + time.second / 3600
         self.day_of_month = time.day
         self.month_of_year = time.month
-        self.timezone = time.strftime("%z")
+        self.timezone = time.strftime("%z")[:3] + ':' + time.strftime("%z")[3:]
         self.ts = Time.timestamp_from_datetime(time)
 
     def to_dict(self):

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1,0 +1,8 @@
+import unittest
+
+from craftai.time import Time
+
+class TestTime(unittest.TestCase):
+
+    def test_timezone_format(self):
+        self.assertEqual(Time(timezone='+01:00').timezone, '+01:00')


### PR DESCRIPTION
Like in the nodejs client, the Time class must have this timezone format: ^[+\-][0-9]{2}:[0-9]{2}$.
Fix the Time class and add related unit test.