### PR TITLE
Support timezones as UTC offset in minutes

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,6 +1,6 @@
 [MASTER]
 
-disable=missing-docstring,locally-enabled,locally-disabled,duplicate-code
+disable=missing-docstring,locally-enabled,locally-disabled,duplicate-code,unnecessary-lambda
 
 [BASIC]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/craft-ai/craft-ai-client-python/compare/v1.14.1...HEAD) ##
 
+### Added
+
+- Support timezones as UTC offset in minutes
+
 ## [1.14.1](https://github.com/craft-ai/craft-ai-client-python/compare/v1.14.0...v1.14.1) - 2018-11-28 ##
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -415,16 +415,22 @@ Each agent has a configuration defining:
 - a `day_of_week` property is an integer belonging to **[0, 6]**, each value represents a day of the week starting from Monday (0 is Monday, 6 is Sunday).
 - a `day_of_month` property is an integer belonging to **[1, 31]**, each value represents a day of the month.
 - a `month_of_year` property is an integer belonging to **[1, 12]**, each value represents a month of the year.
-- a `timezone` property is a string value representing the timezone as an offset from UTC, supported format are:
+- a `timezone` property can be:
+  * a string value representing the timezone as an offset from UTC, supported formats are:
 
-  - **±[hh]:[mm]**,
-  - **±[hh][mm]**,
-  - **±[hh]**,
+    - **±[hh]:[mm]**,
+    - **±[hh][mm]**,
+    - **±[hh]**,
 
-  where `hh` represent the hour and `mm` the minutes from UTC (eg. `+01:30`)), between `-12:00` and
-  `+14:00`.
+    where `hh` represent the hour and `mm` the minutes from UTC (eg. `+01:30`)), between `-12:00` and
+    `+14:00`.
 
-  Some abbreviations are also supported:
+  * an integer belonging to **[-720, 840]** which represents the timezone as an offset from UTC:
+
+    - in hours if the integer belongs to **[-15, 15]**
+    - in minutes otherwise
+
+  * an abbreviation among the following:
 
   - **UTC** or **Z** Universal Time Coordinated,
   - **GMT** Greenwich Mean Time, as UTC,
@@ -1101,7 +1107,7 @@ This function never raises `CraftAiNullDecisionError`, instead it inserts these 
 
 #### `craftai.pandas.utils.create_tree_html` #####
 
-Returns a HTML version of the given decision tree. If this latter is saved in a `.html` file, it can be opened in 
+Returns a HTML version of the given decision tree. If this latter is saved in a `.html` file, it can be opened in
 a browser to be visualized.
 
 ```python
@@ -1122,7 +1128,7 @@ html = create_tree_html(tree)
 
 #### `craftai.pandas.utils.display_tree` #####
 
-Display a decision tree in a Jupyter Notebook. 
+Display a decision tree in a Jupyter Notebook.
 This function can be useful for analyzing the induced decision trees.
 
 ```python

--- a/README.rst
+++ b/README.rst
@@ -518,48 +518,53 @@ Time types: ``timezone``, ``time_of_day``, ``day_of_week``, ``day_of_month`` and
    each value represents a day of the month.
 -  a ``month_of_year`` property is an integer belonging to **[1, 12]**,
    each value represents a month of the year.
--  a ``timezone`` property is a string value representing the timezone
-   as an offset from UTC, supported format are:
+-  a ``timezone`` property can be:
+  - a string value representing the timezone as an offset from UTC, supported formats are:
 
-   -  **±[hh]:[mm]**,
-   -  **±[hh][mm]**,
-   -  **±[hh]**,
+    -  **±[hh]:[mm]**,
+    -  **±[hh][mm]**,
+    -  **±[hh]**,
 
    where ``hh`` represent the hour and ``mm`` the minutes from UTC (eg.
    ``+01:30``)), between ``-12:00`` and ``+14:00``.
 
-   Some abbreviations are also supported:
+  - an integer belonging to **[-720, 840]** which represents the timezone as an offset from UTC
 
-   -  **UTC** or **Z** Universal Time Coordinated,
-   -  **GMT** Greenwich Mean Time, as UTC,
-   -  **BST** British Summer Time, as UTC+1 hour,
-   -  **IST** Irish Summer Time, as UTC+1,
-   -  **WET** Western Europe Time, as UTC,
-   -  **WEST** Western Europe Summer Time, as UTC+1,
-   -  **CET** Central Europe Time, as UTC+1,
-   -  **CEST** Central Europe Summer Time, as UTC+2,
-   -  **EET** Eastern Europe Time, as UTC+2,
-   -  **EEST** Eastern Europe Summer Time, as UTC+3,
-   -  **MSK** Moscow Time, as UTC+3,
-   -  **MSD** Moscow Summer Time, as UTC+4,
-   -  **AST** Atlantic Standard Time, as UTC-4,
-   -  **ADT** Atlantic Daylight Time, as UTC-3,
-   -  **EST** Eastern Standard Time, as UTC-5,
-   -  **EDT** Eastern Daylight Saving Time, as UTC-4,
-   -  **CST** Central Standard Time, as UTC-6,
-   -  **CDT** Central Daylight Saving Time, as UTC-5,
-   -  **MST** Mountain Standard Time, as UTC-7,
-   -  **MDT** Mountain Daylight Saving Time, as UTC-6,
-   -  **PST** Pacific Standard Time, as UTC-8,
-   -  **PDT** Pacific Daylight Saving Time, as UTC-7,
-   -  **HST** Hawaiian Standard Time, as UTC-10,
-   -  **AKST** Alaska Standard Time, as UTC-9,
-   -  **AKDT** Alaska Standard Daylight Saving Time, as UTC-8,
-   -  **AEST** Australian Eastern Standard Time, as UTC+10,
-   -  **AEDT** Australian Eastern Daylight Time, as UTC+11,
-   -  **ACST** Australian Central Standard Time, as UTC+9.5,
-   -  **ACDT** Australian Central Daylight Time, as UTC+10.5,
-   -  **AWST** Australian Western Standard Time, as UTC+8.
+    - in hours if the integer belongs to **[-15, 15]**
+    - in minutes otherwise
+
+  - an abbreviation among the following:
+
+    -  **UTC** or **Z** Universal Time Coordinated,
+    -  **GMT** Greenwich Mean Time, as UTC,
+    -  **BST** British Summer Time, as UTC+1 hour,
+    -  **IST** Irish Summer Time, as UTC+1,
+    -  **WET** Western Europe Time, as UTC,
+    -  **WEST** Western Europe Summer Time, as UTC+1,
+    -  **CET** Central Europe Time, as UTC+1,
+    -  **CEST** Central Europe Summer Time, as UTC+2,
+    -  **EET** Eastern Europe Time, as UTC+2,
+    -  **EEST** Eastern Europe Summer Time, as UTC+3,
+    -  **MSK** Moscow Time, as UTC+3,
+    -  **MSD** Moscow Summer Time, as UTC+4,
+    -  **AST** Atlantic Standard Time, as UTC-4,
+    -  **ADT** Atlantic Daylight Time, as UTC-3,
+    -  **EST** Eastern Standard Time, as UTC-5,
+    -  **EDT** Eastern Daylight Saving Time, as UTC-4,
+    -  **CST** Central Standard Time, as UTC-6,
+    -  **CDT** Central Daylight Saving Time, as UTC-5,
+    -  **MST** Mountain Standard Time, as UTC-7,
+    -  **MDT** Mountain Daylight Saving Time, as UTC-6,
+    -  **PST** Pacific Standard Time, as UTC-8,
+    -  **PDT** Pacific Daylight Saving Time, as UTC-7,
+    -  **HST** Hawaiian Standard Time, as UTC-10,
+    -  **AKST** Alaska Standard Time, as UTC-9,
+    -  **AKDT** Alaska Standard Daylight Saving Time, as UTC-8,
+    -  **AEST** Australian Eastern Standard Time, as UTC+10,
+    -  **AEDT** Australian Eastern Daylight Time, as UTC+11,
+    -  **ACST** Australian Central Standard Time, as UTC+9.5,
+    -  **ACDT** Australian Central Daylight Time, as UTC+10.5,
+    -  **AWST** Australian Western Standard Time, as UTC+8.
 
 ..
 

--- a/craftai/time.py
+++ b/craftai/time.py
@@ -107,7 +107,7 @@ class Time(object):
       if isinstance(timezone, tzinfo):
         # If it's already a timezone object, no more work is needed
         _time = timestamp.astimezone(timezone)
-      elif isinstance(timezone, six.string_types) and is_timezone(timezone):
+      elif is_timezone(timezone):
         # If it's a string, we convert it to a usable timezone object
         offset = timezone_offset_in_sec(timezone)
         _time = timestamp.astimezone(tz=dt_timezone(timedelta(seconds=offset)))

--- a/craftai/timezones.py
+++ b/craftai/timezones.py
@@ -46,8 +46,6 @@ def is_timezone(value):
   result_reg_exp = _TIMEZONE_REGEX.match(value) is not None
   return result_reg_exp
 
-# def get_timezone_key(configuration):
-
 def get_timezone_key(configuration):
   for key in configuration:
     if configuration[key]["type"] == "timezone":
@@ -76,10 +74,10 @@ def timezone_offset_in_sec(timezone):
 
 def timezone_offset_in_standard_format(timezone):
   if isinstance(timezone, six.integer_types):
-    sign = '+' if timezone >= 0 else '-'
+    sign = "+" if timezone >= 0 else "-"
     absolute_offset = abs(timezone)
     if absolute_offset < 16:
-      return  '%s%02d:00' % (sign, absolute_offset)
-    return '%s%02d:%02d' % (sign, int(absolute_offset / 60),
+      return  "%s%02d:00" % (sign, absolute_offset)
+    return "%s%02d:%02d" % (sign, int(absolute_offset / 60),
                             int(absolute_offset % 60))
   return timezone

--- a/craftai/timezones.py
+++ b/craftai/timezones.py
@@ -54,8 +54,8 @@ def get_timezone_key(configuration):
 
 def timezone_offset_in_sec(timezone):
   if isinstance(timezone, six.integer_types):
-    # If the UTC offset is between -16 and +16, consider it as a
-    # number of hours to reproduce the platform's moment behavior
+    # If the offset belongs to [-15, 15] it is considered to represent hours.
+    # This reproduces Moment's utcOffset behaviour.
     if timezone > -16 and timezone < 16:
       return timezone * 60 * 60
     return timezone * 60

--- a/craftai/timezones.py
+++ b/craftai/timezones.py
@@ -1,4 +1,5 @@
 import re
+import six
 
 _TIMEZONE_REGEX = re.compile(r"^([+-](2[0-3]|[01][0-9])(:?[0-5][0-9])?|Z)$")
 
@@ -36,11 +37,30 @@ TIMEZONES = {
 }
 
 def is_timezone(value):
+  if isinstance(value, six.integer_types) and value <= 840 and value >= -720:
+    return True
+  if not isinstance(value, six.string_types):
+    return False
+  if value in TIMEZONES:
+    return True
   result_reg_exp = _TIMEZONE_REGEX.match(value) is not None
-  result_abbreviations = value in TIMEZONES
-  return result_reg_exp or result_abbreviations
+  return result_reg_exp
+
+# def get_timezone_key(configuration):
+
+def get_timezone_key(configuration):
+  for key in configuration:
+    if configuration[key]["type"] == "timezone":
+      return key
+  return None
 
 def timezone_offset_in_sec(timezone):
+  if isinstance(timezone, six.integer_types):
+    # If the UTC offset is between -16 and +16, consider it as a
+    # number of hours to reproduce the platform's moment behavior
+    if timezone > -16 and timezone < 16:
+      return timezone * 60 * 60
+    return timezone * 60
   if timezone in TIMEZONES:
     timezone = TIMEZONES[timezone]
   if len(timezone) > 3:
@@ -53,3 +73,13 @@ def timezone_offset_in_sec(timezone):
     offset = -offset
 
   return offset
+
+def timezone_offset_in_standard_format(timezone):
+  if isinstance(timezone, six.integer_types):
+    sign = '+' if timezone >= 0 else '-'
+    absolute_offset = abs(timezone)
+    if absolute_offset < 16:
+      return  '%s%02d:00' % (sign, absolute_offset)
+    return '%s%02d:%02d' % (sign, int(absolute_offset / 60),
+                            int(absolute_offset % 60))
+  return timezone

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -32,6 +32,9 @@ class TestTime(unittest.TestCase):
     self.assertEqual(Time(t="2017-01-01 00:00:00", timezone="-03:00").timezone, "-03:00")
     self.assertEqual(Time(t="2017-01-01 03:00:00", timezone="+02:00").timezone, "+02:00")
     self.assertEqual(Time(t=datetime(2011, 1, 1, 0, 0), timezone="+02:00").timezone, "+02:00")
+    self.assertEqual(Time(t="2017-01-01 03:00:00", timezone=120).timezone, "+02:00")
+    self.assertEqual(Time(t="2017-01-01 03:00:00", timezone=-120).timezone, "-02:00")
+    self.assertEqual(Time(t="2017-01-01 03:00:00", timezone=-2).timezone, "-02:00")
     self.assertEqual(Time(t=datetime(2012, 9, 12, 6, 0, 0, tzinfo=pytz.utc)).timezone, "+00:00")
     self.assertEqual(Time().timezone, Time().timezone)
 
@@ -45,3 +48,6 @@ class TestTime(unittest.TestCase):
     self.assertRaises(CraftAiTimeError, Time, "2011-04-22 01:00:00+0900", "-03:00")
     self.assertRaises(CraftAiTimeError, Time, datetime(2002, 10, 27, 6, 0, 0,
                                                        tzinfo=pytz.utc), pytz.utc)
+    #Invalid UTC offset
+    self.assertRaises(CraftAiTimeError, Time, "2011-04-22 01:00:00+0900", -950)
+    self.assertRaises(CraftAiTimeError, Time, "2011-04-22 01:00:00+0900", 950)


### PR DESCRIPTION
Part 3 of craft-ai/craft-ai-client-js#130
Support timezones as UTC offset in minutes in the python client