### PR TITLE
Features/errors metadata support

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -34,3 +34,8 @@ ignored-classes=dict
 [REPORTS]
 
 output-format=colorized
+
+[DESIGN]
+
+max-branches=15
+max-locals=20

--- a/craftai/errors.py
+++ b/craftai/errors.py
@@ -1,88 +1,53 @@
 class CraftAiError(Exception):
   """Base class for exceptions in the craft ai client."""
-  def __init__(self, message):
+  def __init__(self, message=None, metadata=None):
     self.message = message
-    super(CraftAiError, self).__init__(message)
+    self.metadata = metadata
+    super(CraftAiError, self).__init__(message, metadata)
 
   def __str__(self):
     return repr(self.message)
 
 
 class CraftAiUnknownError(CraftAiError):
-  """Raised when an unknown error happens in the craft ai client."""
-  def __init__(self, message):
-    self.message = "".join(("Unknown error occured. ", message))
-    super(CraftAiUnknownError, self).__init__(message)
+  """An unknown error occured in the craft ai client."""
 
 
 class CraftAiNetworkError(CraftAiError):
-  """Raised when a network error happens between the client and craft ai"""
-  def __init__(self, message):
-    self.message = "".join(("Network issue: ", message))
-    super(CraftAiNetworkError, self).__init__(message)
+  """A network error occured between the client and craft ai."""
 
 
 class CraftAiCredentialsError(CraftAiError):
-  """Raised when the given credentials for a request or the global config
-  aren't valid """
-  def __init__(self, message):
-    self.message = "".join((
-      "Credentials error: ",
-      message
-    ))
-    super(CraftAiCredentialsError, self).__init__(message)
+  """A credentials error occured."""
 
 
 class CraftAiInternalError(CraftAiError):
-  """Raised when an Internal Server Error (500) happens on craft ai's side"""
-  def __init__(self, message):
-    self.message = "".join(("Internal error occured", message))
-    super(CraftAiInternalError, self).__init__(message)
+  """An Internal Server Error (500) ocurred on craft ai's side."""
 
 
 class CraftAiBadRequestError(CraftAiError):
-  """Raised when the asked request is not valid for craft ai's API"""
-  def __init__(self, message):
-    self.message = "".join(("Bad request: ", message))
-    super(CraftAiBadRequestError, self).__init__(message)
+  """An unvalid request was send to craft ai's API."""
 
 
 class CraftAiNotFoundError(CraftAiError):
-  """Raised when craft ai answers with a Not Found Error (404)"""
-  def __init__(self, message, obj="URL"):
-    self.message = "".join((obj, " not found: ", message))
-    super(CraftAiNotFoundError, self).__init__(message)
+  """A Not Found Error (404) occured on craft ai's side."""
 
 
 class CraftAiDecisionError(CraftAiError):
-  """Raised when some issue is encountered when trying to find a decision"""
-  def __init__(self, message):
-    self.message = "".join(("Unable to take decision, ", message))
-    super(CraftAiDecisionError, self).__init__(message)
+  """An error occured during the decision phase."""
 
 
 class CraftAiNullDecisionError(CraftAiDecisionError):
-  """Raised when some issue is encountered when trying to find a decision"""
-  def __init__(self, message):
-    self.message = "".join(("Unable to take decision, ", message))
-    super(CraftAiNullDecisionError, self).__init__(message)
+  """An error occured during the decision phase."""
 
 
 class CraftAiTimeError(CraftAiError):
-  """Raised when trying to create a time object fails"""
-  def __init__(self, message):
-    self.message = "".join(("Can't create time object: ", message))
-    super(CraftAiTimeError, self).__init__(message)
+  """An error occured during the creation of a craftai.Time instance."""
+
 
 class CraftAiTokenError(CraftAiError):
-  """Raised when the given token is invalid"""
-  def __init__(self, message):
-    self.message = "".join(("Unable to decrypt the JWT token: ", message))
-    super(CraftAiTokenError, self).__init__(message)
+  """An invalid token error occured."""
+
 
 class CraftAiLongRequestTimeOutError(CraftAiError):
-  """Raised when a request takes a long time"""
-  def __init__(self, message=None):
-    self.message = message if message is None else (
-      "Request timed out because the computation is not finished, please try again")
-    super(CraftAiLongRequestTimeOutError, self).__init__(message)
+  """Request timed out because the computation is not finished, please try again."""

--- a/craftai/interpreter_v1.py
+++ b/craftai/interpreter_v1.py
@@ -95,6 +95,7 @@ class InterpreterV1(object):
       if node.get('decision_rule'):
         metadata["decision_rules"].insert(0, node['decision_rule'])
       raise CraftAiDecisionError(err.message, metadata)
+
     new_predicates = [{
       "property": matching_child["decision_rule"]["property"],
       "operator": matching_child["decision_rule"]["operator"],

--- a/craftai/interpreter_v1.py
+++ b/craftai/interpreter_v1.py
@@ -92,8 +92,8 @@ class InterpreterV1(object):
       result = InterpreterV1._decide_recursion(matching_child, context)
     except CraftAiDecisionError as err:
       metadata = err.metadata
-      if node.get('decision_rule'):
-        metadata["decision_rules"].insert(0, node['decision_rule'])
+      if node.get("decision_rule"):
+        metadata["decision_rules"].insert(0, node["decision_rule"])
       raise CraftAiDecisionError(err.message, metadata)
 
     new_predicates = [{

--- a/craftai/interpreter_v1.py
+++ b/craftai/interpreter_v1.py
@@ -35,8 +35,8 @@ class InterpreterV1(object):
     decision_result = {}
     decision_result["output"] = {}
     for output in configuration.get("output"):
-      decision_result["output"][output] = InterpreterV1._decide_recursion(bare_tree[output],
-                                                                          context)
+      decision = InterpreterV1._decide_recursion(bare_tree[output], context)
+      decision_result["output"][output] = decision
 
     decision_result["_version"] = _DECISION_VERSION
     return decision_result
@@ -53,7 +53,8 @@ class InterpreterV1(object):
       if predicted_value is None:
         raise CraftAiNullDecisionError(
           """Unable to take decision: the decision tree has no valid"""
-          """ predicted value for the given context."""
+          """ predicted value for the given context.""",
+          {"decision_rules": [node.get("decision_rule")]}
         )
 
       leaf = {
@@ -73,13 +74,27 @@ class InterpreterV1(object):
 
     if not matching_child:
       prop = node.get("children")[0].get("decision_rule").get("property")
+      operand_list = [child["decision_rule"]["operand"] for child in node["children"]]
+      decision_rule = [node["decision_rule"]] if not node.get("decision_rule") is None else []
       raise CraftAiNullDecisionError(
         """Unable to take decision: value '{}' for property '{}' doesn't"""
-        """ validate any of the decision rules.""".format(context.get(prop), prop)
+        """ validate any of the decision rules.""".format(context.get(prop), prop),
+        {
+          "decision_rules": decision_rule,
+          "expected_values": operand_list,
+          "property": prop,
+          "value": context.get(prop),
+        }
       )
 
     # If a matching child is found, recurse
-    result = InterpreterV1._decide_recursion(matching_child, context)
+    try:
+      result = InterpreterV1._decide_recursion(matching_child, context)
+    except CraftAiDecisionError as err:
+      metadata = err.metadata
+      if node.get('decision_rule'):
+        metadata["decision_rules"].insert(0, node['decision_rule'])
+      raise CraftAiDecisionError(err.message, metadata)
     new_predicates = [{
       "property": matching_child["decision_rule"]["property"],
       "operator": matching_child["decision_rule"]["operator"],
@@ -108,8 +123,7 @@ class InterpreterV1(object):
       if context_value is None:
         raise CraftAiDecisionError(
           """Unable to take decision, property '{}' is missing from the given context.""".
-          format(property_name)
-        )
+          format(property_name))
       if (not isinstance(operator, six.string_types) or
           not operator in OPERATORS.values()):
         raise CraftAiDecisionError(
@@ -168,7 +182,16 @@ class InterpreterV1(object):
           message = "".join((message, ", ", error))
         message = message + "."
 
-        raise CraftAiDecisionError(message)
+        metadata = {}
+        if bad_properties:
+          metadata["badProperties"] = [
+            {"property": p, "type": configuration["context"][p]["type"], "value": context[p]}
+            for p in bad_properties
+          ]
+        if missing_properties:
+          metadata["missingProperties"] = missing_properties
+
+        raise CraftAiDecisionError(message, metadata)
 
   @staticmethod
   def validate_property_value(configuration, context, property_name):

--- a/craftai/interpreter_v2.py
+++ b/craftai/interpreter_v2.py
@@ -121,8 +121,8 @@ class InterpreterV2(object):
                                                path)
     except CraftAiDecisionError as err:
       metadata = err.metadata
-      if node.get('decision_rule'):
-        metadata["decision_rules"].insert(0, node['decision_rule'])
+      if node.get("decision_rule"):
+        metadata["decision_rules"].insert(0, node["decision_rule"])
       raise CraftAiDecisionError(err.message, metadata)
 
     new_predicates = [{

--- a/craftai/interpreter_v2.py
+++ b/craftai/interpreter_v2.py
@@ -124,6 +124,7 @@ class InterpreterV2(object):
       if node.get('decision_rule'):
         metadata["decision_rules"].insert(0, node['decision_rule'])
       raise CraftAiDecisionError(err.message, metadata)
+
     new_predicates = [{
       "property": matching_child["decision_rule"]["property"],
       "operator": matching_child["decision_rule"]["operator"],

--- a/craftai/interpreter_v2.py
+++ b/craftai/interpreter_v2.py
@@ -67,7 +67,8 @@ class InterpreterV2(object):
       if predicted_value is None:
         raise CraftAiNullDecisionError(
           """Unable to take decision: the decision tree has no valid"""
-          """ predicted value for the given context."""
+          """ predicted value for the given context.""",
+          {"decision_rules": [node.get("decision_rule")]}
         )
 
       leaf = {
@@ -99,16 +100,30 @@ class InterpreterV2(object):
       if not deactivate_missing_values:
         return InterpreterV2.compute_distribution(node, output_values, output_type, path)
       prop = node.get("children")[0].get("decision_rule").get("property")
+      operand_list = [child["decision_rule"]["operand"] for child in node["children"]]
+      decision_rule = [node["decision_rule"]] if not node.get("decision_rule") is None else []
       raise CraftAiNullDecisionError(
         """Unable to take decision: value '{}' for property '{}' doesn't"""
-        """ validate any of the decision rules.""".format(context.get(prop), prop)
-        )
+        """ validate any of the decision rules.""".format(context.get(prop), prop),
+        {
+          "decision_rules": decision_rule,
+          "expected_values": operand_list,
+          "property": prop,
+          "value": context.get(prop)
+        }
+      )
     # Add the matching child index to the path
     path.append(str(matching_child_i))
     # If a matching child is found, recurse
-    result = InterpreterV2._decide_recursion(matching_child, context, output_values,
-                                             output_type, deactivate_missing_values,
-                                             path)
+    try:
+      result = InterpreterV2._decide_recursion(matching_child, context, output_values,
+                                               output_type, deactivate_missing_values,
+                                               path)
+    except CraftAiDecisionError as err:
+      metadata = err.metadata
+      if node.get('decision_rule'):
+        metadata["decision_rules"].insert(0, node['decision_rule'])
+      raise CraftAiDecisionError(err.message, metadata)
     new_predicates = [{
       "property": matching_child["decision_rule"]["property"],
       "operator": matching_child["decision_rule"]["operator"],
@@ -312,7 +327,16 @@ class InterpreterV2(object):
           message = "".join((message, ", ", error))
         message = message + "."
 
-        raise CraftAiDecisionError(message)
+        metadata = {}
+        if bad_properties:
+          metadata["badProperties"] = [
+            {"property": p, "type": configuration["context"][p]["type"], "value": context[p]}
+            for p in bad_properties
+          ]
+        if missing_properties:
+          metadata["missingProperties"] = missing_properties
+
+        raise CraftAiDecisionError(message, metadata)
 
   @staticmethod
   def validate_property_value(configuration, context, property_name):

--- a/tests/test_decide.py
+++ b/tests/test_decide.py
@@ -52,7 +52,7 @@ def check_expectation(tree, expectation):
     tree["configuration"].update(configuration)
 
   if expectation.get("error"):
-    with assert_raises(craft_err.CraftAiDecisionError) as context_manager:
+    with assert_raises(craft_err.CraftAiError) as context_manager:
       CLIENT.decide(tree, exp_context, timestamp)
 
     exception = context_manager.exception
@@ -62,6 +62,10 @@ def check_expectation(tree, expectation):
     else:
       expected_message = expectation["error"]["message"].encode("utf8")
     assert_equal(exception.message, expected_message)
+    #print(dir(exception))
+    print(exception.metadata)
+    print(expectation["error"].get("metadata", None))
+    assert_equal(exception.metadata, expectation["error"].get("metadata", None))
   else:
     expected_decision = expectation["output"]
     decision = CLIENT.decide(tree, exp_context, time)

--- a/tests/test_decide.py
+++ b/tests/test_decide.py
@@ -62,9 +62,6 @@ def check_expectation(tree, expectation):
     else:
       expected_message = expectation["error"]["message"].encode("utf8")
     assert_equal(exception.message, expected_message)
-    #print(dir(exception))
-    print(exception.metadata)
-    print(expectation["error"].get("metadata", None))
     assert_equal(exception.metadata, expectation["error"].get("metadata", None))
   else:
     expected_decision = expectation["output"]

--- a/tests/test_decide.py
+++ b/tests/test_decide.py
@@ -52,7 +52,7 @@ def check_expectation(tree, expectation):
     tree["configuration"].update(configuration)
 
   if expectation.get("error"):
-    with assert_raises(craft_err.CraftAiError) as context_manager:
+    with assert_raises(craft_err.CraftAiDecisionError) as context_manager:
       CLIENT.decide(tree, exp_context, timestamp)
 
     exception = context_manager.exception


### PR DESCRIPTION
Add support for errors metadata in the python client.

I had to modify the `craftai.interpreter_vX.decide_recursion` function to collect the decision rules. This costs about 10% in terms of performance.