### PR TITLE
Update client.py to handle bulk timeouts

### DIFF
--- a/craftai/client.py
+++ b/craftai/client.py
@@ -664,7 +664,7 @@ class CraftAIClient(object):
     except (CraftAiInternalError, KeyError, TypeError):
       pass
 
-    if status_code in [200, 201, 204, 207]:
+    if status_code in [200, 201, 202, 204, 207]:
       return CraftAIClient._parse_body(response)
     else:
       raise CraftAIClient._get_error_from_status(status_code, message)


### PR DESCRIPTION
when `get_decision_trees_bulk` get all agents timeouted, it returns a `202`. This status code is not supported in the client.