### PR TITLE
fix 202 status code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.15.8](https://github.com/craft-ai/craft-ai-client-python/compare/v1.15.7...v1.15.8) - 2019-11-19 ##
 
+### Fixed
+
+- Rollback `craftai.client` to raise errors for responses with `202` status code.
+
 ## [1.15.7](https://github.com/craft-ai/craft-ai-client-python/compare/v1.15.6...v1.15.7) - 2019-10-29 ##
 
 ### Fixed

--- a/craftai/client.py
+++ b/craftai/client.py
@@ -664,7 +664,7 @@ class CraftAIClient(object):
     except (CraftAiInternalError, KeyError, TypeError):
       pass
 
-    if status_code in [200, 201, 202, 204, 207]:
+    if status_code in [200, 201, 204, 207]:
       return CraftAIClient._parse_body(response)
     else:
       raise CraftAIClient._get_error_from_status(status_code, message)


### PR DESCRIPTION
Rollback the python client in order not to let 202 be decoded but be raised as errors